### PR TITLE
Port over middleware to external library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,43 @@
 # django-see-profile
 A simple middleware to capture useful profiling information in Django.
+
+## Requirements
+
+* Django 1.10+
+* django-security 0.10.0+
+
+## Description
+
+This is intended to be a simple method for capturing useful profiling
+information from Django for specific requests without interrupting the normal
+program flow or requiring any database tables etc. It makes use of the builtin
+python logging facilities to dump individual requests as a single log message
+and leaving your log configuration to figure out what to do with it.
+
+## Usage
+
+Install as usual for a middleware:
+
+```
+MIDDLEWARES = (
+    ...
+    see_profile.ProfilingMiddleware
+    ...
+)
+```
+
+If you're interested in profiling what's being done in the other middlewares
+you can put it higher in the middleware listing, but if you're just interested
+in view-specific profiling it is recommended to have it fairly close to the
+end of the middlewares list.
+
+To activate the middleware, set `ENABLE_PROFILING` to True, otherwise set it
+to false to deactivate.
+
+The middleware by default does not log every request as it is a performance hit
+and would be fairly noisy when trying to profile in a busy environment, so for
+requests that you desire profiled you are expected to set an `X-Profile` HTTP
+header for the request. The value is immaterial at this time.
+
+All logged requests are sent to the `profiling` logger at the `DEBUG` level,
+so you will need to configure a relevant logger & handler for that.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple middleware to capture useful profiling information in Django.
 ## Requirements
 
 * Django 1.10+
-* django-security 0.10.0+
+* django-security 0.9.0+
 
 ## Description
 

--- a/see_profile/__init__.py
+++ b/see_profile/__init__.py
@@ -1,0 +1,91 @@
+import cProfile
+import logging
+import pstats
+import sqlparse
+from io import StringIO
+
+from django.core.exceptions import MiddlewareNotUsed
+from django.db import connection
+
+from security.middleware import BaseMiddleware
+
+
+class ProfilingMiddleware(BaseMiddleware):
+    """
+    Adds the ability to profile requests via a header.
+
+    Usage:
+    Add the middleware to the MIDDLEWARE list. New boolean setting
+    "ENABLE_PROFILING" will be required to be set in the settings file. When
+    set to False, the middleware will deactivate itself. When set to True, the
+    middleware will be active.
+
+    When the middleware is active, it will log the data for any request that
+    supplies the X-Profile header in the HTTP request. This data will be logged
+    to the 'profiling' logger, so in order to see the results of this profiling
+    the Django logging will need to configure handlers for the 'profiling'
+    logger. Profiling will be configured at the DEBUG level.
+    """
+
+    REQUIRED_SETTINGS = ('ENABLE_PROFILING', 'DEBUG')
+
+    def __init__(self, get_response=None):
+        super().__init__(get_response)
+        if not self.enable_profiling:
+            raise MiddlewareNotUsed()
+        self.logger = logging.getLogger('profiling')
+
+    def load_setting(self, setting, value):
+        setattr(self, setting.lower(), value)
+
+    def format_queries(self, queries):
+        separater = f"\n{'*' * 80}\n"
+        return separater.join(
+            sqlparse.format(query['sql'], reindent=True, keyword_case='upper')
+            for query in queries
+        )
+
+    request_separator = f"\n{'=' * 80}\n"
+
+    def __call__(self, request):
+        # Only profile requests that have a 'X-Profile' HTTP header
+        if 'HTTP_X_PROFILE' not in request.META:
+            return self.get_response(request)
+
+        out = StringIO()
+        out.write(self.request_separator)
+
+        # Add method & path info to differentiate requests
+        out.write(
+            f"{request.method} {request.path}"
+        )
+
+        # We can only profile queries in debug mode
+        if self.debug:
+            num_previous_queries = len(connection.queries)
+
+        # Begin collecting time profiling data
+        profile = cProfile.Profile()
+        profile.enable()
+
+        # Continue down the middleware chain
+        response = self.get_response(request)
+
+        # Stop collecting stats data & return value as string
+        profile_stats = pstats.Stats(profile, stream=out)
+        profile_stats = profile_stats.sort_stats('cumulative')
+        profile_stats.print_stats(128)
+        profile_stats.sort_stats("tottime")
+        profile_stats.print_stats(15)
+
+        # Print out our queries
+        if self.debug:
+            query_count = len(connection.queries) - num_previous_queries
+            out.write(f"\n{query_count} Queries:\n")
+            queries = connection.queries[num_previous_queries:]
+            out.write(self.format_queries(queries))
+
+        out.write(self.request_separator)
+        self.logger.debug(out.getvalue())
+
+        return response

--- a/see_profile/__init__.py
+++ b/see_profile/__init__.py
@@ -41,7 +41,7 @@ class ProfilingMiddleware(BaseMiddleware):
         setattr(self, setting.lower(), value)
 
     def format_queries(self, queries):
-        return self.query_separater.join(
+        return self.query_separator.join(
             sqlparse.format(query['sql'], reindent=True, keyword_case='upper')
             for query in queries
         )

--- a/see_profile/__init__.py
+++ b/see_profile/__init__.py
@@ -56,7 +56,7 @@ class ProfilingMiddleware(BaseMiddleware):
 
         # Add method & path info to differentiate requests
         out.write(
-            f"{request.method} {request.path}"
+            f"{request.method} {request.path}\n\n"
         )
 
         # We can only profile queries in debug mode

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='1.0.1',
-    description='Scoped thread-local mixin class',
+    version='1.0',
+    description='Django middleware for logging profiling data',
     long_description=long_description,
     # The project's main homepage.
     url='https://github.com/sdelements/django-see-profile',
@@ -48,6 +48,6 @@ setup(
     packages=['see_profile'],
     install_requires=[
         "django>=1.10"
-        "django-security>=0.10.0"
+        "django-security>=0.9.0"
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,53 @@
+from setuptools import setup
+from codecs import open
+from os import path
+
+here = path.abspath(path.dirname(__file__))
+
+# Get the long description from the relevant file
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+setup(
+    name='django-see-profile',
+    # Versions should comply with PEP440.  For a discussion on single-sourcing
+    # the version across setup.py and the project code, see
+    # http://packaging.python.org/en/latest/tutorial.html#version
+    version='1.0.1',
+    description='Scoped thread-local mixin class',
+    long_description=long_description,
+    # The project's main homepage.
+    url='https://github.com/sdelements/django-see-profile',
+    # Author details
+    author='Security Compass',
+    author_email='jeff@securitycompass.com',
+    # Choose your license
+    license='MIT',
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        # How mature is this project? Common values are
+        #   3 - Alpha
+        #   4 - Beta
+        #   5 - Production/Stable
+        'Development Status :: 4 - Beta',
+        # Indicate who your project is intended for
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        # Pick your license as you wish (should match "license" above)
+        'License :: OSI Approved :: MIT License',
+        # Specify the Python versions you support here. In particular, ensure
+        # that you indicate whether you support Python 2, Python 3 or both.
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+    ],
+    # What does your project relate to?
+    keywords='django middleware profiling',
+
+    # You can just specify the packages manually here if your project is
+    # simple. Or you can use find_packages().
+    packages=['see_profile'],
+    install_requires=[
+        "django>=1.10"
+        "django-security>=0.10.0"
+    ],
+)


### PR DESCRIPTION
While we were reviewing, we realized that nothing specifically about this middleware was related to the app at large, so it was determined that this would be best to be split into its own separate library.

**Problem**

It can be a bit of a pain to do some profiling in our app. It's relatively easy to get Query-counts via the API with the right logging configuration etc, but it can be difficult to get the results for specific pages in the app, especially older style pages that are nested within iframes or pages that are POST-ed to and redirect on success. Likewise, doing a cProfile traditionally has involved modifying the code to add the profiling where you wanted it.

**Solution**

A middleware has been created in order to make it easier to do profiling on the app without having to interrupt app-flow or modify the code. It is turned on or off via a setting in the app, so it can be left off for production boxes but it is easy to turn off for temporary profiling. It can be used with debug turned off (cProfile data only) and will also record queries if debug is turned on. Individual requests are profiled by setting a specific HTTP header (X-Profile).
This has been pulled out as a separate library so this only represents the

**Testing**

I advise using the branch I've created an MR for in the main app repository for testing this, as it's easiest to test with our existing app. 